### PR TITLE
Update yarn.lock fga-eps-mds/2021.1-Oraculo#202

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7121,6 +7121,11 @@ jsprim@^1.2.2:
     array-includes "^3.1.2"
     object.assign "^4.1.2"
 
+jwt-decode@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
+  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
+
 killable@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"


### PR DESCRIPTION
Após a instalação da bibilioteca jwt-decode, o arquivo yarn.lock não foi commitado junto. fazendo com que o ambiente de homologação desse erro na hora do build.